### PR TITLE
Fix: resolve Zizmor template-injection findings

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -24,20 +24,24 @@ runs:
   steps:
     - name: 'Verify valid directory path'
       shell: bash
+      env:
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
       run: |
         # Verify valid directory path
-        if [ ! -d "${{ inputs.path_prefix }}" ]; then
+        if [ ! -d "$INPUT_PATH_PREFIX" ]; then
           echo 'Error: invalid path/prefix to project directory ❌'; exit 1
         fi
 
     - name: 'Normalize and validate version'
       id: normalize
       shell: bash
+      env:
+        INPUT_REPLACEMENT_VERSION: ${{ inputs.replacement_version }}
       run: |
         set -euo pipefail
         # Normalize and validate version
 
-        input_version="${{ inputs.replacement_version }}"
+        input_version="$INPUT_REPLACEMENT_VERSION"
         echo "Input version: $input_version"
 
         # Strip leading 'v' or 'V' if present (common in Git tags)


### PR DESCRIPTION
## Pull request overview

Zizmor's regular-persona audit (the configuration used by the
organisation-level scheduled scan) reported `template-injection`
findings in this composite action. This change resolves them, bringing
the action to zero medium-or-higher findings.

### Changes

- **template-injection:** the "Verify valid directory path" step
  interpolated `${{ inputs.path_prefix }}`, and the "Normalize and
  validate version" step interpolated `${{ inputs.replacement_version }}`,
  both directly into their bash `run` blocks. Each value is now routed
  through a per-step `env:` block (`INPUT_PATH_PREFIX`,
  `INPUT_REPLACEMENT_VERSION`) and referenced as a quoted shell
  variable so nothing user-controlled is expanded into a run body.

### Impact

No intended behavioural change for valid literal inputs. Note that, by
design, input values are no longer subject to shell/expression
expansion inside the run body (e.g. `$GITHUB_WORKSPACE`, `$HOME`,
`$(...)`, or `${{ ... }}` fragments are now treated as literal text).
That expansion was exactly the unsafe behaviour the
`template-injection` audit flags, so removing it is the point of the
change; any consumer that relied on it should pass an already-expanded
value.
